### PR TITLE
Use mremap on linux to grow map memory (broken)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -3,6 +3,10 @@
 
 #define _DEFAULT_SOURCE
 
+#if defined(GC_REMAP) && defined(__linux__)
+#define _GNU_SOURCE
+#endif
+
 #if defined(__linux__)
 extern char __data_start[];
 extern char __bss_start[];

--- a/include/global_allocator.h
+++ b/include/global_allocator.h
@@ -10,6 +10,7 @@ typedef void (*finalizer_t)(void *);
 
 typedef struct GC_GlobalAllocator {
     size_t small_heap_size;
+    void *small_heap_addr;
     void *small_heap_start;
     void *small_heap_stop;
 
@@ -17,6 +18,7 @@ typedef struct GC_GlobalAllocator {
     BlockList recyclable_list;
 
     size_t large_heap_size;
+    void *large_heap_addr;
     void *large_heap_start;
     void *large_heap_stop;
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -15,8 +15,15 @@
 #define MEM_FD (-1)
 #define MEM_OFFSET (0)
 
-static inline void *GC_map(size_t memory_limit) {
-    void *addr = mmap(NULL, memory_limit, MEM_PROT, MEM_FLAGS, MEM_FD, MEM_OFFSET);
+static inline size_t GC_alignToPageSize(size_t size) {
+    int page_size = getpagesize();
+    size_t aligned_size = size & ~(page_size - 1);
+    if (aligned_size < size) aligned_size += page_size;
+    return aligned_size;
+}
+
+static inline void *GC_map(size_t size) {
+    void *addr = mmap(NULL, size, MEM_PROT, MEM_FLAGS, MEM_FD, MEM_OFFSET);
     if (addr == MAP_FAILED) {
         fprintf(stderr, "GC: mmap error: %s\n", strerror(errno));
         abort();
@@ -24,10 +31,11 @@ static inline void *GC_map(size_t memory_limit) {
     return addr;
 }
 
-static inline void *GC_mapAndAlign(size_t memory_limit, size_t alignment_size) {
-    void *start = GC_map(memory_limit);
-    size_t alignment_mask = ~(alignment_size - 1);
+static inline void *GC_mapAndAlign(void **addr, size_t size, size_t alignment_size) {
+    void *start = GC_map(GC_alignToPageSize(size + BLOCK_SIZE));
+    *addr = start;
 
+    size_t alignment_mask = ~(alignment_size - 1);
     if (((uintptr_t)start & alignment_mask) != (uintptr_t)start) {
         void* previous_block = (void*)((uintptr_t)start & BLOCK_SIZE_IN_BYTES_INVERSE_MASK);
         start = (char*)previous_block + BLOCK_SIZE;
@@ -39,5 +47,21 @@ static inline void *GC_mapAndAlign(size_t memory_limit, size_t alignment_size) {
 static inline size_t GC_getMemoryLimit() {
     return (size_t)sysconf(_SC_PHYS_PAGES) * (size_t)sysconf(_SC_PAGESIZE);
 }
+
+#if defined(GC_REMAP)
+static inline void GC_remap(void *addr, size_t old_size, size_t new_size) {
+    void *ret = mremap(addr, old_size, new_size, 0);
+    if (ret == MAP_FAILED) {
+        fprintf(stderr, "GC: mremap error: %s\n", strerror(errno));
+        abort();
+    }
+}
+
+static inline void GC_remapAligned(void *addr, size_t old_size, size_t new_size) {
+    old_size = GC_alignToPageSize(old_size + BLOCK_SIZE);
+    new_size = GC_alignToPageSize(new_size + BLOCK_SIZE);
+    GC_remap(addr, old_size, new_size);
+}
+#endif // GC_REMAP
 
 #endif

--- a/test/block_list_test.c
+++ b/test/block_list_test.c
@@ -14,7 +14,8 @@ TEST test_BlockList_clear() {
 }
 
 TEST test_BlockList_push() {
-    void *heap = GC_mapAndAlign(BLOCK_SIZE * 4, BLOCK_SIZE * 4);
+    void *addr;
+    void *heap = GC_mapAndAlign(&addr, BLOCK_SIZE * 4, BLOCK_SIZE * 4);
 
     BlockList list;
     BlockList_clear(&list);
@@ -56,7 +57,8 @@ TEST test_BlockList_push() {
 }
 
 TEST test_BlockList_shift() {
-    void *heap = GC_mapAndAlign(BLOCK_SIZE * 4, BLOCK_SIZE * 4);
+    void *addr;
+    void *heap = GC_mapAndAlign(&addr, BLOCK_SIZE * 4, BLOCK_SIZE * 4);
 
     BlockList list;
     BlockList_clear(&list);

--- a/test/memory_test.c
+++ b/test/memory_test.c
@@ -3,7 +3,8 @@
 
 TEST test_mapAndAlign() {
     // mapped memory
-    void *start = GC_mapAndAlign(32768 * 4, 32768);
+    void *addr;
+    void *start = GC_mapAndAlign(&addr, 32768 * 4, 32768);
     ASSERT(start != NULL);
 
     // aligned memory start


### PR DESCRIPTION
Instead of mapping an absurd amount of memory, this patch attempts to only allocate the current size we need, and then call mremap to grow the memory.

Despite retaining the original address of the map (not the block aligned one), and making sure to align the map sizes to the kernel page size, mremap fails to grow the memory from the initial 4MB to 5MB.

refs #17 